### PR TITLE
Fixes issue #1

### DIFF
--- a/php-siridb.h
+++ b/php-siridb.h
@@ -1,6 +1,6 @@
 #ifndef PHP_SIRIDB_H
 #define PHP_SIRIDB_H 1
-#define PHP_SIRIDB_WORLD_VERSION "1.0"
+#define PHP_SIRIDB_WORLD_VERSION "0.0.2"
 #define PHP_SIRIDB_WORLD_EXTNAME "php-siridblib"
 
 

--- a/siridb.c
+++ b/siridb.c
@@ -78,7 +78,7 @@ PHP_FUNCTION(siridb_connect)
     size_t password_len;
     char *dbname;
     size_t dbname_len;
-    int port;
+    long port;
     
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "slsss", &hostname, &hostname_len, &port, &username, &username_len, &password, &password_len, &dbname, &dbname_len) == FAILURE) {
         zend_throw_exception(zend_exception_get_default(TSRMLS_C), "Incorrect method parameters for siridb_connect", 0 TSRMLS_CC);


### PR DESCRIPTION
Catching the variable `l` using `zend_parse_parameters(...)` requires a type `long`.

The current variable was of type `int` and this causes the segmentation fault on Linux.